### PR TITLE
Enhancements

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 class Group < ApplicationRecord
-  validates :name, presence: true
-  validates :icon, presence: true
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :icon, presence: true, length: { maximum: 100 }
   belongs_to :user
   has_many :groups_items
   has_many :items, -> { order(id: :desc) }, through: :groups_items

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 100 }
   validates :amount, numericality: { only_integer: true, greater_than: 0 }
   validate :group_presence
   belongs_to :user, foreign_key: :author_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :validatable
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
   has_many :items, foreign_key: :author_id
   has_many :groups
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -13,10 +13,18 @@ RSpec.describe Group, type: :model do
       group.name = ''
       expect(group).to_not(be_valid)
     end
+    it 'should not exceed 100 characters' do
+      group.name = 'a' * 1000
+      expect(group).to_not(be_valid)
+    end
   end
   describe 'icon attribute' do
     it 'should not be blank' do
       group.icon = ''
+      expect(group).to_not(be_valid)
+    end
+    it 'should not exceed 100 characters' do
+      group.name = 'a' * 1000
       expect(group).to_not(be_valid)
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Item, type: :model do
       item.name = ''
       expect(item).to_not(be_valid)
     end
+    it 'should not exceed 100 characters' do
+      item.name = 'a' * 1000
+      expect(item).to_not(be_valid)
+    end
   end
   describe 'amount attribute' do
     it 'should not be blank' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe User, type: :model do
       user.name = ''
       expect(user).to_not(be_valid)
     end
+    it 'should not exceed 50 characters' do
+      user.name = 'a' * 100
+      expect(user).to_not(be_valid)
+    end
   end
   describe 'email attribute' do
     it 'should not be blank' do


### PR DESCRIPTION
- Set maximum length validation rule for `name` attribute in `User` model to 50
- Set maximum length validation rule for `name` attribute in `Group` & `Item` models to 100
- Set maximum length validation rule for `icon` attribute in `Group` model to 100
- Added unit tests for all length validation rules in all models